### PR TITLE
Change rspec version to 3.1.0, version 3.1.0 does not exists yet

### DIFF
--- a/resize_validation.gemspec
+++ b/resize_validation.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.0.0'
-  spec.add_development_dependency 'rspec', '~> 3.1.7'
+  spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
The rspec 3.1.7 does not exists yet. Specifying this version causes the following error:

MacBook-Pro-de-Patricio:Validation psantos$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Could not find gem 'rspec (~> 3.1.7) ruby' in the gems available on this machine.